### PR TITLE
Rz imu more stuff changes

### DIFF
--- a/src/host/pages/IMUMonitorPage.cpp
+++ b/src/host/pages/IMUMonitorPage.cpp
@@ -28,14 +28,13 @@
   THE SOFTWARE.
 */
 
-#include <stdio.h>
-#include "common/signalk/SKUpdate.h"
+
 #include "IMUMonitorPage.h"
-#include <KBoxLogging.h>
-#include "signalk/SKUnits.h"
+
+#include "common/signalk/SKUpdate.h"
+#include "common/signalk/SKUnits.h"
 
 IMUMonitorPage::IMUMonitorPage(IMUConfig &config, SKHub& hub, IMUService &imuService) : _config(config), _imuService(imuService) {
-
   static const int col1 = 5;
   static const int col2 = 200;
   static const int row1 = 26;
@@ -67,7 +66,7 @@ bool IMUMonitorPage::processEvent(const ButtonEvent &be){
     return false;
   }
   if (be.clickType == ButtonEventTypeLongClick) {
-    _imuService.setHeelPitchOffset();
+    _imuService.setRollPitchOffset();
   }
   return true;
 }
@@ -82,8 +81,8 @@ bool IMUMonitorPage::processEvent(const TickEvent &te){
   _rollTL->setText(String( SKRadToDeg(_roll), 1) + "°     ");
 
   // Always show Hdg from IMU-sensor, but if the value is not trusted (which means
-  // calibration below default setting, change color to red
-  if ( ! _imuService.isMagCalibrated() || ! _imuService.isHeelAndPitchCalibrated()) {
+  // calibrationData below default setting, change color to red
+  if ( ! _imuService.isMagCalibrated() || ! _imuService.isRollAndPitchCalibrated()) {
     _hdgTL->setColor(ColorRed);
     _calTL->setColor(ColorRed);
   } else {

--- a/src/host/services/IMUService.cpp
+++ b/src/host/services/IMUService.cpp
@@ -152,8 +152,7 @@ bool IMUService::saveHeelPitchOffset() {
   if (PersistentStorage::writeImuHeelPitchOffsets(o)) {
     DEBUG("Storing offset data to EEPROM...");
     return true;
-  }
-  else {
+  } else {
     ERROR("Error saving IMU Offsets for heel and pitch to flash.");
     return false;
   }
@@ -167,8 +166,7 @@ bool IMUService::readHeelPitchOffset() {
     _offsetRoll = o.offsetHeel / 1000.0;
     _offsetPitch = o.offsetPitch / 1000.0;
     return true;
-  }
-  else {
+  } else {
     ERROR("Error reading IMU Offsets for heel and pitch from flash.");
     return false;
   }
@@ -194,8 +192,7 @@ bool IMUService::saveCalibrationOffsets() {
   if (PersistentStorage::writeBNO055CalOffsets(o)) {
     DEBUG("BNO055 Calibration Offsets written to flash.");
     return true;
-  }
-  else {
+  } else {
     ERROR("Error saving BNO055 Calibration Offsets to flash.");
     return false;
   }
@@ -221,8 +218,7 @@ bool IMUService::readCalibrationOffsets() {
     bno055.setSensorOffsets(c);
     DEBUG("BNO055 Calibration Offsets recalled from flash.");
     return true;
-  }
-  else {
+  } else {
     ERROR("Error recalling BNO055 Calibration Offsets from EEPROM");
     return false;
   }

--- a/src/host/services/IMUService.cpp
+++ b/src/host/services/IMUService.cpp
@@ -28,11 +28,19 @@
 #include "IMUService.h"
 #include "host/util/PersistentStorage.h"
 
+IMUService::IMUService(IMUConfig &config, SKHub &skHub) :
+  Task("IMU"),  _config(config), _skHub(skHub),
+  _timeSinceLastCalSave(resaveCalibrationTimeMs) {
+
+}
+
 void IMUService::setup() {
-  _timeSinceLastSetOffset = 0;
   _offsetRoll  = 0.0;
   _offsetPitch = 0.0;
 
+  // Remap is 00zzyyxx
+  // Where each can be 00:X, 01: Y, 10:Z
+  // Sign is the 3 lsb: 00000xyz
   switch (_config.mounting) {
     case HorizontalLeftSideToBow:
       _axisConfig = 0b00100100;
@@ -41,7 +49,6 @@ void IMUService::setup() {
     case VerticalTopToBow:
     case VerticalStbHull:
     case VerticalPortHull:
-    default:
       _axisConfig = 0b00001001;
       _signConfig = 0b00000000;
   }
@@ -51,23 +58,20 @@ void IMUService::setup() {
     DEBUG("Error initializing BNO055");
   }
   else {
-    // read calibration and offset values for heel & pitch from flash
-    readCalibrationOffsets();
-    readHeelPitchOffset();
+    // read calibrationData and offset values for heel & pitch from flash
+    restoreCalibration();
   }
 }
 
 void IMUService::loop() {
   bno055.getCalibration(&_sysCalib, &_gyroCalib, &_accelCalib, &_magCalib);
-  //DEBUG("Calib Sys: %i Accel: %i Gyro: %i Mag: %i", _sysCalib, _accelCalib, _gyroCalib, _magCalib);
-
-  eulerAngles = bno055.getVector(Adafruit_BNO055::VECTOR_EULER);
-  //DEBUG("Sensor Raw-datas: eulerAngles.z=%.3f eulerAngles.y=%.3f  eulerAngles.x=%.3f", eulerAngles.z(), eulerAngles.y(), eulerAngles.x());
+  imu::Vector<3> eulerAngles = bno055.getVector(Adafruit_BNO055::VECTOR_EULER);
 
   SKUpdateStatic<2> update;
-  // Note: We could calculate yaw as the difference between the Magnetic
-  // Heading and the Course Over Ground Magnetic.
 
+  // In the SignalK Specification
+  //  roll:   Vessel roll, +ve is list to starboard
+  //  pitch:  Pitch, +ve is bow up
   switch (_config.mounting) {
     case VerticalPortHull:
       _roll = SKDegToRad(eulerAngles.z());
@@ -91,25 +95,27 @@ void IMUService::loop() {
     break;
   }
 
-  // update NavigationHeadingMagnetic if quality (= calibration value) is ok
   if (isMagCalibrated()) {
     update.setNavigationHeadingMagnetic(_heading);
   }
-  // update NavigationAttitude if quality (= calibration value) is ok
-  if (isHeelAndPitchCalibrated()) {
-    update.setNavigationAttitude(SKTypeAttitude(/* roll */ _roll + _offsetRoll, /* pitch */ _pitch + _offsetPitch, /* yaw */ SKDoubleNAN));
-    //DEBUG("Heel = %.3f | Pitch = %.3f | Heading = %.3f", SKRadToDeg( _roll + _offsetRoll), SKRadToDeg( _pitch + _offsetPitch), SKRadToDeg(_heading));
+
+  if (isRollAndPitchCalibrated()) {
+    // Yaw is always NAN. We cannot really measure it with our instruments.
+    update.setNavigationAttitude(SKTypeAttitude( _roll + _offsetRoll,
+                                                 _pitch + _offsetPitch,
+                                                 SKDoubleNAN));
   }
   _skHub.publish(update);
 
-  // Save calibration values to EEPROM every 30 Minutes, if BNO055 is fully calibrated
-  if (bno055.isFullyCalibrated() && _timeSinceLastCalSave > 1800000) {
-    if (saveCalibrationOffsets())
-      _timeSinceLastCalSave = 0;
+  // Save calibrationData values to EEPROM every 30 Minutes, if BNO055 is fully calibrated
+  if (bno055.isFullyCalibrated() &&
+      _timeSinceLastCalSave > resaveCalibrationTimeMs) {
+    saveCalibration();
+    _timeSinceLastCalSave = 0;
   }
 }
 
-// get the actual values of calibration, heel & pitch (including offset) and heading for display
+// get the actual values of calibrationData, heel & pitch (including offset) and heading for display
 // all angles in radians
 void IMUService::getLastValues(int &sysCalibration, int &accelCalibration, double &pitch, double &roll, int &magCalibration, double &heading){
   sysCalibration = _sysCalib;
@@ -124,7 +130,7 @@ void IMUService::getLastValues(int &sysCalibration, int &accelCalibration, doubl
 //  (e.g. called with long button press in IMUMonitorPage)
 //  If an setOffset will be done a second time within 5 Seconds,
 //  the values will be stored into EEPROM and loaded at start of KBox
-void IMUService::setHeelPitchOffset() {
+void IMUService::setRollPitchOffset() {
   bool changed = false;
   if (abs(_roll) < M_PI / 2 ) {
     _offsetRoll = _roll * (-1);
@@ -136,90 +142,60 @@ void IMUService::setHeelPitchOffset() {
   }
 
   if ( changed ) {
-    INFO("Offset changed: Heel -> %.3f | Pitch -> %.3f", SKRadToDeg(_offsetRoll), SKRadToDeg(_offsetPitch));
-    if (_timeSinceLastSetOffset < 5000) {
-      saveHeelPitchOffset();
+    INFO("Offset changed: Heel -> %.3f | Pitch -> %.3f",
+         SKRadToDeg(_offsetRoll), SKRadToDeg(_offsetPitch));
+    DEBUG("Offset changed: Heel -> %.3f | Pitch -> %.3f", _offsetRoll,
+          _offsetPitch);
+    saveCalibration();
+    _timeSinceLastCalSave = 0;
+  }
+}
+
+bool IMUService::saveCalibration() {
+  struct PersistentStorage::IMUCalibration calibration;
+
+  // This will verify at compile time that there is enough space in the
+  // persistent storage structure to save all the calibration registers.
+  static_assert(sizeof(calibration.calibrationData) ==
+                NUM_BNO055_OFFSET_REGISTERS,
+    "Not enough space in PersistentStorage::IMUCalibration to store BNO055 "
+      "calibration data.");
+
+  calibration.mountingPosition = static_cast<uint8_t>(_config.mounting);
+  if (! bno055.getSensorOffsets(calibration.calibrationData)) {
+    ERROR("Cannot save calibration while not fully calibrated.");
+    return false;
+  }
+  calibration.offsetPitch =
+    static_cast<int>(_offsetPitch * offsetScalingValueToInt);
+  calibration.offsetRoll =
+    static_cast<int>(_offsetRoll * offsetScalingValueToInt);
+
+  if (PersistentStorage::writeIMUCalibration(calibration)) {
+    DEBUG("IMU Calibration written to flash.");
+    return true;
+  } else {
+    ERROR("Error saving IMU Calibration to flash.");
+    return false;
+  }
+}
+
+bool IMUService::restoreCalibration() {
+  struct PersistentStorage::IMUCalibration calibration;
+
+  if (PersistentStorage::readIMUCalibration(calibration)) {
+    if (calibration.mountingPosition != _config.mounting) {
+      DEBUG("Mounting position has changed. Discarding previous calibration.");
+      return false;
     }
-  }
-  _timeSinceLastSetOffset = 0;
-}
-
-bool IMUService::saveHeelPitchOffset() {
-  struct PersistentStorage::IMUHeelPitchOffsets o;
-  o.offsetHeel = (int) _offsetRoll * 1000;
-  o.offsetPitch = (int) _offsetPitch * 1000;
-
-  if (PersistentStorage::writeImuHeelPitchOffsets(o)) {
-    DEBUG("Storing offset data to EEPROM...");
+    bno055.setSensorOffsets(calibration.calibrationData);
+    _offsetPitch = calibration.offsetPitch / offsetScalingValueToInt;
+    _offsetRoll = calibration.offsetRoll / offsetScalingValueToInt;
+    DEBUG("IMU Calibration recalled from flash.");
     return true;
   } else {
-    ERROR("Error saving IMU Offsets for heel and pitch to flash.");
+    ERROR("Error recalling IMU Calibration from flash");
     return false;
   }
 }
 
-bool IMUService::readHeelPitchOffset() {
-  struct PersistentStorage::IMUHeelPitchOffsets o;
-
-  if (PersistentStorage::readImuHeelPitchOffsets(o)) {
-    DEBUG("Recalling offset data from EEPROM...");
-    _offsetRoll = o.offsetHeel / 1000.0;
-    _offsetPitch = o.offsetPitch / 1000.0;
-    return true;
-  } else {
-    ERROR("Error reading IMU Offsets for heel and pitch from flash.");
-    return false;
-  }
-}
-
-bool IMUService::saveCalibrationOffsets() {
-  adafruit_bno055_offsets_t c;
-  bno055.getSensorOffsets(c);
-
-  struct PersistentStorage::BNO055CalOffsets o;
-  o.accel_offset_x = c.accel_offset_x;
-  o.accel_offset_y = c.accel_offset_y;
-  o.accel_offset_z = c.accel_offset_z;
-  o.gyro_offset_x = c.gyro_offset_x;
-  o.gyro_offset_y = c.gyro_offset_y;
-  o.gyro_offset_z = c.gyro_offset_z;
-  o.mag_offset_x = c.mag_offset_x;
-  o.mag_offset_y = c.mag_offset_y;
-  o.mag_offset_z = c.mag_offset_z;
-  o.accel_radius = c.accel_radius;
-  o.mag_radius = c.mag_radius;
-
-  if (PersistentStorage::writeBNO055CalOffsets(o)) {
-    DEBUG("BNO055 Calibration Offsets written to flash.");
-    return true;
-  } else {
-    ERROR("Error saving BNO055 Calibration Offsets to flash.");
-    return false;
-  }
-}
-
-bool IMUService::readCalibrationOffsets() {
-  adafruit_bno055_offsets_t c;
-  struct PersistentStorage::BNO055CalOffsets o;
-
-  if (PersistentStorage::readBNO055CalOffsets(o)) {
-    c.accel_offset_x = o.accel_offset_x;
-    c.accel_offset_y = o.accel_offset_y;
-    c.accel_offset_z = o.accel_offset_z;
-    c.gyro_offset_x = o.gyro_offset_x;
-    c.gyro_offset_y = o.gyro_offset_y;
-    c.gyro_offset_z = o.gyro_offset_z;
-    c.mag_offset_x = o.mag_offset_x;
-    c.mag_offset_y = o.mag_offset_y;
-    c.mag_offset_z = o.mag_offset_z;
-    c.accel_radius = o.accel_radius;
-    c.mag_radius = o.mag_radius;
-
-    bno055.setSensorOffsets(c);
-    DEBUG("BNO055 Calibration Offsets recalled from flash.");
-    return true;
-  } else {
-    ERROR("Error recalling BNO055 Calibration Offsets from EEPROM");
-    return false;
-  }
-}

--- a/src/host/util/PersistentStorage.cpp
+++ b/src/host/util/PersistentStorage.cpp
@@ -108,39 +108,18 @@ bool PersistentStorage::writeNMEA2000Parameters(struct NMEA2000Parameters &p) {
   return write(nmea2000ParamsAddress, &p, sizeof(NMEA2000Parameters));
 }
 
-// reads calibration offset values of BNO055 IMU sensor
-bool PersistentStorage::readBNO055CalOffsets(struct BNO055CalOffsets &o) {
+bool PersistentStorage::readIMUCalibration(struct IMUCalibration &o){
   if (!isInitialized()) {
     return false;
   }
 
-  if (!read(bno055CalOffsetsAddress, &o, sizeof(BNO055CalOffsets))) {
-    return false;
-  }
-  return true;
+  return read(imuCalibrationAddress, &o, sizeof(IMUCalibration));
 }
 
-bool PersistentStorage::writeBNO055CalOffsets(struct BNO055CalOffsets &o) {
+bool PersistentStorage::writeIMUCalibration(struct IMUCalibration &o) {
   if (!isInitialized()) {
     initialize();
   }
 
-  return write(bno055CalOffsetsAddress, &o, sizeof(BNO055CalOffsets));
-}
-
-bool PersistentStorage::readImuHeelPitchOffsets(IMUHeelPitchOffsets &o) {
-  if (!isInitialized()) {
-    initialize();
-  }
-
-
-  return false;
-}
-
-bool PersistentStorage::writeImuHeelPitchOffsets(IMUHeelPitchOffsets &o){
-  if (!isInitialized()) {
-    initialize();
-  }
-
-  return false;
+  return write(imuCalibrationAddress, &o, sizeof(IMUCalibration));
 }

--- a/src/host/util/PersistentStorage.h
+++ b/src/host/util/PersistentStorage.h
@@ -36,7 +36,7 @@
 static const uint32_t storageMagic = 0xB0A7F107;
 
 // This needs to be updated when the flash storage becomes incompatible!
-static const uint32_t storageVersion = 1;
+static const uint32_t storageVersion = 2;
 
 
 class PersistentStorage {
@@ -65,23 +65,11 @@ class PersistentStorage {
       };
     };
 
-    struct BNO055CalOffsets {
-      uint16_t accel_offset_x;
-      uint16_t accel_offset_y;
-      uint16_t accel_offset_z;
-      uint16_t gyro_offset_x;
-      uint16_t gyro_offset_y;
-      uint16_t gyro_offset_z;
-      uint16_t mag_offset_x;
-      uint16_t mag_offset_y;
-      uint16_t mag_offset_z;
-      uint16_t accel_radius;
-      uint16_t mag_radius;
-    };
-
-    struct IMUHeelPitchOffsets {
-      int offsetHeel;
-      int offsetPitch;
+    struct IMUCalibration {
+      uint8_t mountingPosition;
+      uint8_t calibrationData[22]; // NUM_BNO055_OFFSET_REGISTERS
+      int16_t offsetRoll;
+      int16_t offsetPitch;
     };
 
   private:
@@ -89,11 +77,12 @@ class PersistentStorage {
     static const uint16_t magicAddress = 0;
     static const uint16_t versionAddress = 4;
     static const uint16_t nmea2000ParamsAddress = 8;
-    static const uint16_t bno055CalOffsetsAddress = 20;     // 11 x 2 Byte
-    static const uint16_t imuHeelPitchOffsetsAddress = 42;  //  2 x 2 Byte
+    static const uint16_t imuCalibrationAddress =
+      nmea2000ParamsAddress + sizeof(NMEA2000Parameters);
 
     // Size of flash
-    static const uint16_t storageUsed = 46;
+    static const uint16_t storageUsed = 8 + sizeof(struct NMEA2000Parameters)
+      + sizeof(IMUCalibration);
     static const uint16_t storageSize = 2048; // Teensy 3.2
     //static const uint16_t storageSize = 4096; // Teensy 3.6
 
@@ -109,9 +98,6 @@ class PersistentStorage {
     static bool readNMEA2000Parameters(struct NMEA2000Parameters &p);
     static bool writeNMEA2000Parameters(struct NMEA2000Parameters &p);
 
-    static bool readBNO055CalOffsets(struct BNO055CalOffsets &o);
-    static bool writeBNO055CalOffsets(struct BNO055CalOffsets &o);
-
-    static bool readImuHeelPitchOffsets(struct IMUHeelPitchOffsets &o);
-    static bool writeImuHeelPitchOffsets(struct IMUHeelPitchOffsets &o);
+    static bool readIMUCalibration(struct IMUCalibration &o);
+    static bool writeIMUCalibration(struct IMUCalibration &o);
 };


### PR DESCRIPTION
Few changes to IMUService and calibration:
 - Use an array for BNO055 calibration data to avoid having to assign
 registers one by one.
 - Save IMUCalibration with offsets since we are very likely to
 read/write them together.
 - Also include with calibration the mounting position because the
 calibration very likely needs to be rest when the mounting position
 changes.
 - Use "roll" everywhere instead of pitch

@ronzeiller please take a look and merge in your branch if you are happy.

I am still not very happy with how this all works. The BNO055 is still not immediately calibrated when it boots and I am still seeing some very weird values coming out of it. I am going to continue experimenting with this for a little bit and also make sure that the signs and values are correct for all mounting position.